### PR TITLE
fix(go.mod): Downgrade Go version in go.mod to 1.23.0 for compatibility with Viper.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Tools
+Copyright (c) 2021 SV-Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ An extension for Golang [Viper](https://github.com/spf13/viper) library to use a
 
 ## Usage
 
+```shell
+go get github.com/sv-tools/viper-template@latest
+```
+
 ```go
 package main
 
@@ -54,13 +58,16 @@ func main() {
 
 ## Benchmarks
 
-### `v1.5.0`
-using go `v1.21.3`
+### `v1.9.0`
+using go `v1.23.9`
 
 ```
+% go test -bench=. -benchmem
+
 goos: darwin
 goarch: arm64
 pkg: github.com/sv-tools/viper-template
-BenchmarkGetParallel-8            807338              1510 ns/op            4329 B/op         43 allocs/op
-BenchmarkGetSequential-8          431893              2716 ns/op            4327 B/op         43 allocs/op
+cpu: Apple M1
+BenchmarkGetParallel-8            757263              1582 ns/op            4330 B/op         43 allocs/op
+BenchmarkGetSequential-8          417817              2780 ns/op            4328 B/op         43 allocs/op
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/sv-tools/viper-template
 
-go 1.24.0
+go 1.23.0
+
 require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Update benchmarks in README to reflect v1.9.0 using Go 1.23.9 and Apple M1
architecture. Add installation instructions for easier user setup. Correct
copyright holder in LICENSE from "Tools" to "SV-Tools". Downgrade Go version
in go.mod to 1.23.0 for compatibility.