### PR TITLE
feat(ci): split Go version lookup and make jobs matrix-aware

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,13 +18,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  UnitTests:
+  GoVersions:
+    name: Lookup Go versions
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+      latest: ${{ steps.versions.outputs.latest }}
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action
-      - uses: actions/setup-go@v5.5.0 # immutable action
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: arnested/go-version-action@81f730770833dd20e6365d535ce7efcb3b136e7d #v1.1.21
+        id: versions
+
+  UnitTestJob:
+    runs-on: ubuntu-latest
+    needs: GoVersions
+    strategy:
+      matrix:
+        go: ${{ fromJSON(needs.GoVersions.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go }}
       - run: go install github.com/jstemmer/go-junit-report/v2@latest
       - run: go test -race -cover -coverprofile=coverage.out -covermode=atomic
       - run: go test -json 2>&1 | go-junit-report -parser gojson > junit.xml
@@ -40,13 +55,23 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  GolangCI-Lint:
+  UnitTests:
+    if: ${{ always() }}
+    needs: UnitTestJob
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action
-      - uses: actions/setup-go@v5.5.0 # immutable action
+      - name: Check status
+        if: ${{ needs.UnitTestJob.result != 'success' }}
+        run: exit 1
+
+  GolangCI-Lint:
+    needs: GoVersions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.5.0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ needs.GoVersions.outputs.latest }}
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest


### PR DESCRIPTION
Introduce a dedicated GoVersions job that discovers supported Go versions
and exposes a and latest version as outputs. Use those outputs to
drive UnitTestJob's matrix and to select the Go version for GolangCI-Lint,
so tests and linters run against the discovered versions rather than a
single hardcoded file.

Replace direct setup-go usage that reads go.mod with explicit go-version
inputs sourced from the new matrix/latest outputs. Make checkout and
setup-go actions reference immutable SHAs consistently.

Add a lightweight UnitTests job that always runs after UnitTestJob to
report non-success test status (exits with failure when tests fail).
This clarifies job responsibilities and improves CI parallelization and
version coverage.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #160 
- <kbd>&nbsp;1&nbsp;</kbd> #159 👈 
<!-- GitButler Footer Boundary Bottom -->

